### PR TITLE
Add RedHat support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,9 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
+    - name: EL
+      versions:
+        - 7
   categories:
     - networking
     - system

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,16 @@
+---
+- name: "Install Packages | package manager"
+  package:
+    state: latest
+    name: "{{ item }}"
+    update_cache: yes
+  with_items: "{{ packages }}"
+  tags:
+    - codedeploy
+
+- name: "Check if CodeDeploy is already installed"
+  command: dpkg-query -W 'codedeploy-agent'
+  ignore_errors: True
+  register: is_codedeploy_installed
+  tags:
+    - codedeploy

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,22 @@
+---
+- name: "Ensure the epel repo is installed"
+  package:
+    name: epel-release
+    state: present
+  tags:
+    - codedeploy
+
+- name: "Install Packages | package manager"
+  package:
+    state: present
+    name: "{{ item }}"
+  with_items: "{{ packages }}"
+  tags:
+    - codedeploy
+
+- name: "Check if CodeDeploy is already installed"
+  command: rpm -q 'codedeploy-agent'
+  ignore_errors: True
+  register: is_codedeploy_installed
+  tags:
+    - codedeploy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,37 +1,49 @@
 ---
-- name: Install Packages | apt
-  apt:
-    state: latest
-    name: "{{ item }}"
-    update_cache: yes
-  with_items:
-    - python-pip
-    - ruby2.0
-    - git
+- name: "Load variables specific to this OS"
+  include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - codedeploy
 
-- name: Install Packages | pip
+- include: "{{ ansible_os_family }}.yml"
+  tags:
+    - codedeploy
+
+- name: "Install Packages | pip"
   pip:
-    state: latest
+    state: present
     name: "{{ item }}"
   with_items:
     - awscli
+  tags:
+    - codedeploy
 
-- name: Get Instance Metadata | ec2
+- name: "Get Instance Metadata | ec2"
   action: ec2_facts
+  tags:
+    - codedeploy
 
-- name: Get CodeDeploy | s3
+- name: "Get CodeDeploy | s3"
   get_url:
     url: "https://aws-codedeploy-{{ ansible_ec2_placement_region }}.s3.amazonaws.com/latest/install"
     dest: /tmp/codedeploy-install
+  when: is_codedeploy_installed|failed
+  tags:
+    - codedeploy
 
-- name: Codedeploy Install Binary | Permission Executable
+- name: "Codedeploy Install Binary | Permission Executable"
   file:
     state: file
     path: /tmp/codedeploy-install
-    group: www-data
-    owner: www-data
-    mode: 0777
+    group: root
+    owner: root
+    mode: 0755
+  when: is_codedeploy_installed|failed
+  tags:
+    - codedeploy
 
-- name: Codedeploy Install
+- name: "Codedeploy Install"
   become: true
   command: /tmp/codedeploy-install auto
+  when: is_codedeploy_installed|failed
+  tags:
+    - codedeploy

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,4 @@
+packages:
+  - python-pip
+  - ruby2.0
+  - git

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+packages:
+  - python2-pip
+  - ruby
+  - git


### PR DESCRIPTION
Tested on CentOS 7.

Also added:
  - If the CodeDeploy package is already installed, don't re-install.
  - `codedeploy` tags, so it's possible to use `--tags=codedeploy`
